### PR TITLE
update path

### DIFF
--- a/dg-build.sh
+++ b/dg-build.sh
@@ -25,9 +25,9 @@ function add_env_var {
 
 function download_miniconda {
     if [ `uname` = "Darwin" ]; then
-	URL=https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh
+	URL=https://repo.anaconda.com/miniconda/Miniconda2-latest-MacOSX-x86_64.sh
     else
-	URL=https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
+	URL=https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86_64.sh
     fi
     curl $URL -o /tmp/miniconda.sh
 }


### PR DESCRIPTION
VectorHive builds are [failing](https://app.circleci.com/pipelines/github/deepgenomics/VectorHive/608/workflows/55e6bcee-64b4-4cee-820f-895204e7d6d0/jobs/1637). Turns out the miniconda install being pulled down is an empty file. Googling brings up another path which seems to work. 